### PR TITLE
feat: support config path flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A zero-dependency CLI to merge Markdown rule files and write them to multiple ID
 Run the CLI with command-line args only:
 
 ```
-npx copy-agent-rules <src_dir> <dest_dir> [--formats <list>] [--overwrite]
+npx copy-agent-rules <src_dir> <dest_dir> [--formats <list>] [--overwrite] [--config <file>]
 npx copy-agent-rules -h | --help
 ```
 
@@ -16,6 +16,7 @@ Arguments:
 - `dest_dir`: target project root to receive outputs
 - `--formats`: comma-separated list, overrides formats from `config.js`
 - `--overwrite`: overwrite existing files without prompt
+- `--config <file>`: use config from the given file (default: `./config.js`)
 - `-h, --help`: show help and list available formats (read from `config.js`)
 
 Available formats (default, from `config.js`):
@@ -26,6 +27,12 @@ chatgpt-codex, claude, cline, codex, cursor, gemini, kiro, vscode, windsurf
 Example:
 ```
 npx copy-agent-rules src dist --formats codex,cursor --overwrite
+```
+
+During execution the CLI prints the path of the loaded config:
+
+```
+using config from /path/to/config.js
 ```
 
 ### For git-cloned users (local development)

--- a/tests/_testcase-bin.js
+++ b/tests/_testcase-bin.js
@@ -65,4 +65,23 @@ export async function testHelpOutput(t) {
     await t.assert(res.out.toLowerCase().includes('available formats'), 'help should include formats list');
 }
 
+export async function testConfigFlag(t) {
+    t.log('config flag: custom path');
+    const tmp_src = await t.mkTmpDir('car-src');
+    const tmp_dest = await t.mkTmpDir('car-dest');
+    await t.writeFile(path.join(tmp_src, 'a.md'), '# A');
+
+    const tmp_cfg_dir = await t.mkTmpDir('car-cfg');
+    const cfg_path = path.join(tmp_cfg_dir, 'cfg.mjs');
+    await t.writeFile(cfg_path, `export default {\n  overwrite: false,\n  formats: ['codex'],\n  formats_dict: { codex: { filename: 'from-config.md' } }\n};`);
+
+    const res = await t.runCli([tmp_src, tmp_dest, '--config', cfg_path]);
+    await t.assert(res.code === 0, 'cli exit 0');
+    await t.assert(res.out.includes('using config from'), 'should log config path');
+    await t.assert(res.out.includes(cfg_path), 'should show cfg path');
+
+    const exists = await fs.access(path.join(tmp_dest, 'from-config.md')).then(() => true).catch(() => false);
+    await t.assert(exists, 'should generate file from config');
+}
+
 

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -60,7 +60,7 @@ class Tester {
 }
 
 import { testConfigLoadAndValidate } from './_testcase-config.js';
-import { testBasicMergeAndOutputs, testOverwriteFlag, testHelpOutput } from './_testcase-bin.js';
+import { testBasicMergeAndOutputs, testOverwriteFlag, testHelpOutput, testConfigFlag } from './_testcase-bin.js';
 
 async function main() {
     const t = new Tester();
@@ -69,6 +69,7 @@ async function main() {
         await testBasicMergeAndOutputs(t);
         await testOverwriteFlag(t);
         await testHelpOutput(t);
+        await testConfigFlag(t);
         t.log('All tests passed.');
     } catch (e) {
         console.error('Test failed:', e.message);


### PR DESCRIPTION
## Summary
- add `--config` flag to load custom config file
- show loaded config path at runtime
- document flag and add tests for custom config
- fix config flag test to use ESM `.mjs` file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689654260154833297646425da3e8727