### PR TITLE
feat: accept single file src path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ GitHub repository: [applepig/copy-agent-rules](https://github.com/applepig/copy-
 Run the CLI with command-line args only:
 
 ```
-npx copy-agent-rules <src_dir> <dest_dir> [--formats <list>] [--overwrite] [--config <file>]
+npx copy-agent-rules <src_path> <dest_dir> [--formats <list>] [--overwrite] [--config <file>]
 npx copy-agent-rules -h | --help
 ```
 
 Arguments:
-- `src_dir`: directory containing one or more `.md` files (merged by filename order)
+- `src_path`: directory containing one or more `.md` files (merged by filename order) or a single `.md` file
 - `dest_dir`: target project root to receive outputs
 - `--formats`: comma-separated list, overrides formats from `config.js`
 - `--overwrite`: overwrite existing files without prompt
@@ -47,7 +47,7 @@ Main files:
  - `tests/tester.js`: zero-dependency E2E test runner.
 
 Common scripts:
-- `npm run copy -- <src_dir> <dest_dir> [--formats <list>] [--overwrite]`
+- `npm run copy -- <src_path> <dest_dir> [--formats <list>] [--overwrite]`
 - `npm test`
 
 Config (ESM, `config.js`):
@@ -64,7 +64,7 @@ export default {
 ```
 
 Notes:
-- All `.md` in `src_dir` are merged with a `<!-- source: <file> -->` marker.
+- All `.md` in `src_path` are merged with a `<!-- source: <file> -->` marker.
 - `prepend` (optional) adds per-format content to the very top.
 
 ### License

--- a/tests/_testcase-bin.js
+++ b/tests/_testcase-bin.js
@@ -35,6 +35,29 @@ export async function testBasicMergeAndOutputs(t) {
     await t.assert(cursor_content.startsWith('---'), 'cursor content should include frontmatter prepend');
 }
 
+export async function testSingleFileSrc(t) {
+    t.log('single file: setup');
+    const tmp_dir = await t.mkTmpDir('car-single');
+    const tmp_dest = await t.mkTmpDir('car-dest');
+    const src_file = path.join(tmp_dir, 'single.md');
+    await t.writeFile(src_file, '# One');
+
+    t.log('single file: run CLI');
+    const { code } = await t.runCli([src_file, tmp_dest, '--formats', 'codex', '--overwrite']);
+    t.log(`cli exit=${code}`);
+    if (code !== 0) {
+        throw new Error('CLI should exit 0');
+    }
+
+    const codex_path = path.join(tmp_dest, 'codex.md');
+    const codex_exists = await fs.access(codex_path).then(() => true).catch(() => false);
+    await t.assert(codex_exists, 'codex.md should exist');
+
+    const codex_content = await t.readFile(codex_path);
+    await t.assert(codex_content.includes('# One'), 'should include file content');
+    await t.assert(codex_content.includes('source: single.md'), 'should include source marker');
+}
+
 export async function testOverwriteFlag(t) {
     t.log('overwrite: setup');
     const tmp_src = await t.mkTmpDir('car-src');

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -60,13 +60,14 @@ class Tester {
 }
 
 import { testConfigLoadAndValidate } from './_testcase-config.js';
-import { testBasicMergeAndOutputs, testOverwriteFlag, testHelpOutput, testConfigFlag } from './_testcase-bin.js';
+import { testBasicMergeAndOutputs, testSingleFileSrc, testOverwriteFlag, testHelpOutput, testConfigFlag } from './_testcase-bin.js';
 
 async function main() {
     const t = new Tester();
     try {
         await testConfigLoadAndValidate(t);
         await testBasicMergeAndOutputs(t);
+        await testSingleFileSrc(t);
         await testOverwriteFlag(t);
         await testHelpOutput(t);
         await testConfigFlag(t);


### PR DESCRIPTION
## Summary
- allow using a single markdown file as the source path
- document the `src_path` option in README
- add test coverage for single-file source

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68971c51e1548332950c736f503e950c